### PR TITLE
Fixes the order of the values in the rockchip-ebc: override temp message

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_ebc.c
+++ b/drivers/gpu/drm/rockchip/rockchip_ebc.c
@@ -1084,7 +1084,7 @@ static void rockchip_ebc_refresh(struct rockchip_ebc *ebc,
 		temperature /= 1000;
 
 		if (temp_override > 0){
-			printk(KERN_INFO "rockchip-ebc: override temperature from %i to %i\n", temp_override, temperature);
+			printk(KERN_INFO "rockchip-ebc: override temperature from %i to %i\n", temperature, temp_override);
             temperature = temp_override;
         }
 


### PR DESCRIPTION
Just a suggestion will probably create a merge conflict with the temp_offset