### PR TITLE
Ebc offset temp

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_ebc.c
+++ b/drivers/gpu/drm/rockchip/rockchip_ebc.c
@@ -260,6 +260,10 @@ static int temp_override = 0;
 module_param(temp_override, int, S_IRUGO|S_IWUSR);
 MODULE_PARM_DESC(temp_override, "Values > 0 override the temperature");
 
+static int temp_offset = 0;
+module_param(temp_offset, int, S_IRUGO|S_IWUSR);
+MODULE_PARM_DESC(temp_offset, "Values > 0 is subtracted from the temperature to compensate for the pcb sensor being hotter than the display");
+
 
 DEFINE_DRM_GEM_FOPS(rockchip_ebc_fops);
 
@@ -1087,6 +1091,14 @@ static void rockchip_ebc_refresh(struct rockchip_ebc *ebc,
 			printk(KERN_INFO "rockchip-ebc: override temperature from %i to %i\n", temp_override, temperature);
             temperature = temp_override;
         }
+        	} else if (temp_offset > 0){
+			int old_val = temperature;
+			if (temperature > temp_offset)
+				temperature -= temp_offset;
+			else
+				temperature = 0;
+			printk(KERN_INFO "rockchip-ebc: temp offset from %i to %i\n", old_val, temperature);
+		}
 
 		ret = drm_epd_lut_set_temperature(&ebc->lut, temperature);
 		if (ret < 0)

--- a/drivers/gpu/drm/rockchip/rockchip_ebc.c
+++ b/drivers/gpu/drm/rockchip/rockchip_ebc.c
@@ -1089,8 +1089,7 @@ static void rockchip_ebc_refresh(struct rockchip_ebc *ebc,
 
 		if (temp_override > 0){
 			printk(KERN_INFO "rockchip-ebc: override temperature from %i to %i\n", temp_override, temperature);
-            temperature = temp_override;
-        }
+            		temperature = temp_override;
         	} else if (temp_offset > 0){
 			//int old_val = temperature;
 			if (temperature > temp_offset)

--- a/drivers/gpu/drm/rockchip/rockchip_ebc.c
+++ b/drivers/gpu/drm/rockchip/rockchip_ebc.c
@@ -264,6 +264,10 @@ static int temp_offset = 0;
 module_param(temp_offset, int, S_IRUGO|S_IWUSR);
 MODULE_PARM_DESC(temp_offset, "Values > 0 is subtracted from the temperature to compensate for the pcb sensor being hotter than the display");
 
+static int panel_temp = 0;
+module_param(panel_temp, int, S_IRUGO);
+MODULE_PARM_DESC(panel_temp, "The currently used value for the panel temperature");
+
 
 DEFINE_DRM_GEM_FOPS(rockchip_ebc_fops);
 
@@ -1098,6 +1102,7 @@ static void rockchip_ebc_refresh(struct rockchip_ebc *ebc,
 				temperature = 0;
 			//printk(KERN_INFO "rockchip-ebc: temp offset from %i to %i\n", old_val, temperature);
 		}
+		panel_temp = temperature;
 
 		ret = drm_epd_lut_set_temperature(&ebc->lut, temperature);
 		if (ret < 0)

--- a/drivers/gpu/drm/rockchip/rockchip_ebc.c
+++ b/drivers/gpu/drm/rockchip/rockchip_ebc.c
@@ -1092,12 +1092,12 @@ static void rockchip_ebc_refresh(struct rockchip_ebc *ebc,
             temperature = temp_override;
         }
         	} else if (temp_offset > 0){
-			int old_val = temperature;
+			//int old_val = temperature;
 			if (temperature > temp_offset)
 				temperature -= temp_offset;
 			else
 				temperature = 0;
-			printk(KERN_INFO "rockchip-ebc: temp offset from %i to %i\n", old_val, temperature);
+			//printk(KERN_INFO "rockchip-ebc: temp offset from %i to %i\n", old_val, temperature);
 		}
 
 		ret = drm_epd_lut_set_temperature(&ebc->lut, temperature);


### PR DESCRIPTION
- Adds a /sys variable for a temperature offset for the panel
- Changes some white spaces to tabs(8 wide) as per kernel guideline
- Adds a /sys variable for polling the panel temperature