### PR TITLE
arm64: dts: rockchip: add 'chassis-type' property on PineNote

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-pinenote.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-pinenote.dtsi
@@ -10,6 +10,8 @@
 #include "rk3566.dtsi"
 
 / {
+	chassis-type = "tablet";
+
 	aliases {
 		mmc0 = &sdhci;
 	};


### PR DESCRIPTION
Add the recommended chassis-type root node property so userspace can request the form factor and adjust their behavior accordingly.


Link: https://github.com/devicetree-org/devicetree-specification/blob/main/source/chapter3-devicenodes.rst#root-node