### PR TITLE
arm64: dts: rockchip: Fix cover detection on PineNote

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-pinenote.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-pinenote.dtsi
@@ -101,7 +101,7 @@
 			label = "cover";
 			gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_LOW>;
 			linux,input-type = <EV_SW>;
-			linux,code = <SW_MACHINE_COVER>;
+			linux,code = <SW_LID>;
 			linux,can-disable;
 			wakeup-event-action = <EV_ACT_DEASSERTED>;
 			wakeup-source;


### PR DESCRIPTION
The SW_MACHINE_COVER switch event was added to input event codes to detect the removal of the back cover of the N900.
But on the PineNote its purpose is to detect when the front cover gets closed, just like when a laptop lid is closed. Therefore SW_LID is the appropriate linux code and not SW_MACHINE_COVER.

Reported-by: hrdl <git@hrdl.eu>
Helped-by: phantomas <phantomas@phantomas.xyz>
Link: https://lore.kernel.org/r/270f27c9-afd6-171d-7dce-fe1d71dd8f9a@wizzup.org/
Signed-off-by: Diederik de Haas <didi.debian@cknow.org>
Link: https://lore.kernel.org/r/20250526161506.139028-1-didi.debian@cknow.org
Signed-off-by: Heiko Stuebner <heiko@sntech.de>

---
This was applied upstream here: https://git.kernel.org/pub/scm/linux/kernel/git/mmind/linux-rockchip.git/commit/?h=v6.17-armsoc/dts64&id=3f391123e2bc88c570f148cc01e923e4740c5173